### PR TITLE
Change the default states we notify for

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ Label examples:
 Labels are colon `:` delimited.
 
 1. The first section must be `slack`.
-2. The second section is the Slack target. You can specify a channel, username, channel ID (C12345678), or user ID (U12345678).
-3. The third section is optional. You can specify the run states that will generate notifications. By default, it is `unconfirmed,failure` (runs waiting for confirmation or failed).
+2. The second section is the Slack target. You can specify a channel (`#foo`), username (`user.name`), channel ID (`C12345XYZ`), or user ID (`U12345XYZ`). (If you want to specify multiple targets, add one label for each.)
+3. The third section is optional. You can specify the run states that will generate notifications. By default, it is `failure`. Comma-separate multiple states.
+
+### Spacelift States
+
+There's no authoritative list of states in Spacelift's docs. The closest you'll find is [the page on run states](https://docs.spacelift.io/concepts/run). Here's an incomplete list for your convenience: `queued`, `preparing`, `initializing`, `planning`, `unconfirmed`, `confirmed`, `applying`, `finished`, `failure`, `destroying`, `performing`.
 
 ## Installation
 

--- a/app/src/rule.ts
+++ b/app/src/rule.ts
@@ -1,6 +1,9 @@
 import { NotificationRule } from "./notification"
 import { SpaceliftRunEvent } from "./spacelift"
 
+/** Default stack states to notify about. */
+const DEFAULT_STATES = ['failed']
+
 /**
  * Is this event interesting to a specific rule. Check the rule cares about the
  * state (eg INITIALIZING, FINISHED).
@@ -21,8 +24,7 @@ export function runEventIsInterestingToRule(event: SpaceliftRunEvent, rule: Noti
  *      user.name) or the Slack ID (C12345678, U12345678).
  *   STATE is a Spacelift stack state in lower-case. For instance: initializing,
  *      finished, failed, etc. You can specify multiple states by separating
- *      them with commas. If you don't specify any states, the default is
- *      "unconfirmed, failed".
+ *      them with commas. If you don't specify any states, the default is used.
  *
  * @param label Label to parse
  * @returns Array containing the parsed rule or nothing
@@ -32,6 +34,6 @@ export function parseSlackLabel(label: string): [NotificationRule] | [] {
   if (prefix !== 'slack' || !target) {
     return []
   }
-  const states = states_str ? states_str.split(',').map(s => s.toLowerCase()) : ['failed', 'unconfirmed']
+  const states = states_str ? states_str.split(',').map(s => s.toLowerCase()) : DEFAULT_STATES
   return [{ states, target }]
 }


### PR DESCRIPTION
Was: finished,unconfirmed
Now: finished

Notifying for every unconfirmed run was overly spammy. It was leading to
alert fatigue where people were ignoring most notifications from the
bot.

Instead, only notify on run failures. In this way, the signal-to-noise
ratio should be extremely high.

Ideally, we would only like to be notified about unconfirmed runs that
have been forgotten. A heuristic might be "not confirmed within x
minutes". That would be a nice future feature...