### PR TITLE
Show only the first 10 characters of run IDs

### DIFF
--- a/app/src/slack.ts
+++ b/app/src/slack.ts
@@ -41,7 +41,7 @@ export function generateSlackMessage(event: SpaceliftRunEvent): SlackMessagePayl
       },
       {
         type: "mrkdwn",
-        text: `*Run:* <${event.run.url}|${event.run.id}>`
+        text: `*Run:* <${event.run.url}|${event.run.id.slice(0, 10)}>`
       },
       {
         type: "mrkdwn",


### PR DESCRIPTION
ULIDs are 10 character timestamp + 16 character random data. For these
messages, the timestamp (millisecond accuracy) will be more than unique
enough.